### PR TITLE
Adjust quiz pacing and hide auto answers

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
         </label>
         <button id="startButton">開始測驗</button>
         <button id="resetButton" class="secondary">重新開始</button>
-        <span class="hint">提示：開始後會依序朗讀完整短句（每題間隔 15 秒）。</span>
+        <span class="hint">提示：開始後會依序朗讀完整短句（每題間隔 35 秒）。</span>
       </div>
 
       <div id="quizArea"></div>
@@ -110,8 +110,7 @@
           el.classList.remove('correct','incorrect');
           el.classList.add(isOk? 'correct':'incorrect');
           const ans = el.parentElement.querySelector('.answer');
-          if(!isOk) ans.classList.add('show');
-          else ans.classList.remove('show');
+          ans.classList.remove('show');
           if(isOk) correct++;
         });
         resultBar.classList.remove('muted');
@@ -156,8 +155,8 @@
         currentSentences = shuffle(pool).slice(0, n);
         renderQuiz(currentSentences);
 
-        // 依序朗讀（每題間隔 15 秒）
-        const gap = 15000; // 15s
+        // 依序朗讀（每題間隔 35 秒）
+        const gap = 35000; // 35s
         currentSentences.forEach((it, idx) => {
           const t = setTimeout(() => {
             // 朗讀完整句（包含被空格遮住的詞）


### PR DESCRIPTION
## Summary
- increase the speech interval between questions to 35 seconds
- prevent answers from being revealed automatically after the last question

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da2f96b7648325b2bba1bc3328a72e